### PR TITLE
Flavio/issue 15

### DIFF
--- a/orangecontrib/storynavigation/modules/constants.py
+++ b/orangecontrib/storynavigation/modules/constants.py
@@ -25,6 +25,9 @@ NL = 'nl'
 EN = 'en'
 SUPPORTED_LANGUAGES = [EN, NL]
 
+# Number of story segments
+N_STORY_SEGMENTS = list(range(1,11))
+
 # filename from which to retrieve a list of dutch stopwords
 NL_STOPWORDS_FILENAME = "dutchstopwords.txt"
 # filename from which to retrieve a list of dutch past tense verbs

--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -15,6 +15,9 @@ class Tagger:
     """Class to perform NLP tagging of relevant actors and actions in textual stories
     For the storynavigator Orange3 add-on:
     https://pypi.org/project/storynavigator/0.0.11/
+
+    Args:
+        n_segments (int): Number of segments to split each story into.
     """
     def __init__(self, lang, n_segments, text_tuples, custom_tags_and_word_column=None):
         self.text_tuples = text_tuples
@@ -69,7 +72,8 @@ class Tagger:
             nlp (spacy.language.Language): a spacy language model object to use on the input stories
 
         Returns:
-            pandas.DataFrame: a dataframe containing all tagging data for the given story
+            pandas.DataFrame: a dataframe containing all tagging data for the given story, and a column with the segment.
+            The segment is the segment number of the corresponding sentence in a given story.
         """
         story_df = pd.DataFrame()
         sentences = util.preprocess_text(story_text)

--- a/orangecontrib/storynavigation/widgets/OWSNTagger.py
+++ b/orangecontrib/storynavigation/widgets/OWSNTagger.py
@@ -30,7 +30,7 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
     autocommit = Setting(True)
     language = 'nl'
     word_column = 'word'
-    n_segments = 0
+    n_segments = 0 # this selects the the first entry in the list constants.N_STORY_SEGMENTS 
 
     def __init__(self):
         super().__init__()
@@ -138,10 +138,14 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
         if self.stories is not None:
             if len(self.stories) > 0:
                 if self.custom_tag_dict is not None:
-                    self.tagger = Tagger(lang=self.language, text_tuples=self.stories, custom_tags_and_word_column=(self.custom_tag_dict, self.word_column))
+                    self.tagger = Tagger(
+                        lang=self.language, n_segments=int(self.n_segments), text_tuples=self.stories, 
+                        custom_tags_and_word_column=(self.custom_tag_dict, self.word_column))
                     print('Both corpus and custom tags are available!')
                 else:
-                    self.tagger = Tagger(lang=self.language, text_tuples=self.stories, custom_tags_and_word_column=None)
+                    self.tagger = Tagger(
+                        lang=self.language, n_segments=int(self.n_segments), text_tuples=self.stories, 
+                        custom_tags_and_word_column=None)
                     print('ONLY corpus is available!')
 
 
@@ -213,12 +217,16 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
 
         
 
-# if __name__ == "__main__":
-#     from orangewidget.utils.widgetpreview import WidgetPreview
+if __name__ == "__main__":
+    from orangewidget.utils.widgetpreview import WidgetPreview
 
-#     from orangecontrib.text.preprocess import BASE_TOKENIZER
+    from orangecontrib.text.preprocess import BASE_TOKENIZER
 
-#     corpus_ = Corpus.from_file("book-excerpts")
-#     corpus_ = corpus_[:3]
-#     corpus_ = BASE_TOKENIZER(corpus_)
-#     WidgetPreview(OWSNDSGTagger).run(corpus_)
+    # corpus_ = Corpus.from_file("book-excerpts")
+    corpus_ = Corpus.from_file("orangecontrib/storynavigation/tests/storynavigator-testdata.tab")
+    corpus_ = corpus_[:3]
+    corpus_ = BASE_TOKENIZER(corpus_)
+    previewer = WidgetPreview(OWSNTagger)
+    # breakpoint()
+    previewer.run(set_stories=corpus_, no_exit=True)
+    # WidgetPreview(OWSNTagger).run(set_stories=corpus_)

--- a/orangecontrib/storynavigation/widgets/OWSNTagger.py
+++ b/orangecontrib/storynavigation/widgets/OWSNTagger.py
@@ -30,6 +30,7 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
     autocommit = Setting(True)
     language = 'nl'
     word_column = 'word'
+    n_segments = 0
 
     def __init__(self):
         super().__init__()
@@ -64,8 +65,21 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
 
         self.controlArea.layout().addWidget(self.select_word_column_combo)
 
+        self.select_n_segments_combo = gui.comboBox(
+            widget=self.controlArea,
+            master=self,
+            label="Number of segments per story",
+            value="n_segments",
+            items=constants.N_STORY_SEGMENTS,
+            sendSelectedValue=True,
+            sizePolicy=QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
+        )
+
+        self.controlArea.layout().addWidget(self.select_n_segments_combo)
+
         self.select_language_combo.setEnabled(True)
         self.select_word_column_combo.setEnabled(True)
+        self.select_n_segments_combo.setEnabled(True)
         
         self.compute_data_button = gui.button(
             self.controlArea,

--- a/orangecontrib/storynavigation/widgets/OWSNTagger.py
+++ b/orangecontrib/storynavigation/widgets/OWSNTagger.py
@@ -135,16 +135,19 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
         self.Warning.clear()
 
     def __generate_dataset_level_data(self):
+        n_segments = int(self.n_segments)
+        if n_segments == 0: # if the user does not choose explicitly the value in the menu, the value will be 0.
+            n_segments = 1 
         if self.stories is not None:
             if len(self.stories) > 0:
                 if self.custom_tag_dict is not None:
                     self.tagger = Tagger(
-                        lang=self.language, n_segments=int(self.n_segments), text_tuples=self.stories, 
+                        lang=self.language, n_segments=n_segments, text_tuples=self.stories, 
                         custom_tags_and_word_column=(self.custom_tag_dict, self.word_column))
                     print('Both corpus and custom tags are available!')
                 else:
                     self.tagger = Tagger(
-                        lang=self.language, n_segments=int(self.n_segments), text_tuples=self.stories, 
+                        lang=self.language, n_segments=n_segments, text_tuples=self.stories, 
                         custom_tags_and_word_column=None)
                     print('ONLY corpus is available!')
 


### PR DESCRIPTION
##### Issue
Closes #15 


##### Description of changes
- added the drop-down menu to the gui
- segment the story by sentence; created second dataframe with one row per sentence


**Open questions**
- [x] the resulting dataframe is not outputted anywhere. one solution would be to have a data structure with a set of relational dataframes/tables, and this datastructure can then be used as input in downstream widgets. 
- [x] where to define the type of the `comboBox`? currently I have to transform from `str` to `int` in line 142 and line 147 of `orangecontrib/storynavigation/widgets/OWSNTagger.py`. Ideally we change the type when when the tagger is instantiated and the input value changes


The number of segments are computed with the `np.array_split`. Because the number of segments is now defined at a global level (for all stories), it can create highly unequal segment sizes when there is large variability in the length across stories (and thus, statistical conclusions from comparing segments within a story will be more or less accurate depending on the size of the segment). 
One way to deal with this is to represent this uncertainty to the user and write a clear documentation about it, perhaps including a hint that the user should inspect the segment length in their stories. 
Another way could be to let the user define, instead of (or in addition to?) the number of segments, the minimum segment size they want. 


##### Includes
- [X] Code changes
- [ ] Tests
- [x] Documentation
