### PR TITLE
add error when input channel is not corpus

### DIFF
--- a/orangecontrib/storynavigation/modules/error_handling.py
+++ b/orangecontrib/storynavigation/modules/error_handling.py
@@ -14,6 +14,12 @@ msg_wrong_input_for_elements = (
     "The input to `Stories` needs to be a `Corpus`."
 ) 
 
+msg_wrong_story_input_for_elements = (
+    "Wrong input to `Stories`. "
+    "The input to `Stories` needs to be a `Corpus`. \n"
+    "The input to `Custom tags` needs to be a `Table`."
+) 
+
 msg_residual_error = (
     "Could not process data. Check the inputs to the widget."
 )
@@ -21,6 +27,7 @@ msg_residual_error = (
 wrong_input_for_stories = Msg(msg_wrong_input_for_stories)
 residual_error = Msg(msg_residual_error)
 wrong_input_for_elements = Msg(msg_wrong_input_for_elements)
+wrong_story_input_for_elements = Msg(msg_wrong_story_input_for_elements)
 
 
 __all__ = [

--- a/orangecontrib/storynavigation/modules/error_handling.py
+++ b/orangecontrib/storynavigation/modules/error_handling.py
@@ -1,0 +1,28 @@
+"Define error messages to be used in the Actor and Action analysis"
+
+from Orange.widgets.widget import Msg
+
+msg_wrong_input_for_stories = (
+    "Wrong input to `Stories`. "
+    "The input to `Story elements` needs to be a `Table`. \n"
+    "The input to `Stories` needs to be a `Corpus`." 
+)
+
+msg_wrong_input_for_elements = (
+    "Wrong input to `Story elements`. "
+    "The input to `Story elements` needs to be a `Table`. \n"
+    "The input to `Stories` needs to be a `Corpus`."
+) 
+
+msg_residual_error = (
+    "Could not process data. Check the inputs to the widget."
+)
+
+wrong_input_for_stories = Msg(msg_wrong_input_for_stories)
+residual_error = Msg(msg_residual_error)
+wrong_input_for_elements = Msg(msg_wrong_input_for_elements)
+
+
+__all__ = [
+    "wrong_input_for_stories", "wrong_input_for_elements", "residual_error"
+]

--- a/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
@@ -47,6 +47,8 @@ from orangecontrib.text.corpus import Corpus
 from storynavigation.modules.actionanalysis import ActionTagger
 import storynavigation.modules.constants as constants
 import storynavigation.modules.util as util
+import storynavigation.modules.error_handling as error_handling
+
 
 HTML = """
 <!doctype html>
@@ -328,25 +330,10 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
 
 
     class Error(OWWidget.Error):
-        msg_wrong_input_for_stories = (
-            "Wrong input to `Stories`. "
-            "The input to `Story elements` needs to be a `Table`. \n"
-            "The input to `Stories` needs to be a `Corpus`." 
-        )
-        wrong_input_for_stories = Msg(msg_wrong_input_for_stories)
-
-        msg_wrong_input_for_elements = (
-            "Wrong input to `Story elements`. "
-            "The input to `Story elements` needs to be a `Table`. \n"
-            "The input to `Stories` needs to be a `Corpus`."
-        ) 
-        wrong_input_for_elements = Msg(msg_wrong_input_for_elements)
-
-        msg_residual_error = (
-            "Could not process data. Check the inputs to the widget."
-        )
-        residual_error = Msg(msg_residual_error)
-
+        wrong_input_for_stories = error_handling.wrong_input_for_stories
+        wrong_input_for_elements = error_handling.wrong_input_for_elements
+        residual_error = error_handling.residual_error
+        
 
     settingsHandler = DomainContextHandler()
     settings_version = 2

--- a/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
@@ -498,7 +498,9 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
 
     @Inputs.stories
     def set_stories(self, stories=None):
-
+        """Stories expects a Corpus. Because Corpus is a subclass of Table, Orange type checking 
+        misses wrongly connected inputs.         
+        """
         if not isinstance(stories, Corpus):
             self.Error.wrong_input_for_stories()
         else:
@@ -506,6 +508,7 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
             self.Error.clear()
 
         if self.story_elements is not None:
+            self.Error.clear()
             self.start(
                 self.run, 
                 self.story_elements
@@ -518,23 +521,25 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
 
     @Inputs.story_elements
     def set_story_elements(self, story_elements=None):
+        """Story elements expects a table. Because Corpus is a subclass of Table, Orange type checking 
+        misses wrongly connected inputs."""
         if isinstance(story_elements, Corpus): 
             self.Error.wrong_input_for_elements()
-
-        if story_elements is not None:
-            self.Error.clear()
-            # try:
-            self.story_elements = util.convert_orangetable_to_dataframe(story_elements)
-            self.actiontagger = ActionTagger(self.story_elements['lang'].tolist()[0])
-            self.start(
-                self.run, 
-                self.story_elements
-            )
-            self.postags_box.setEnabled(True)
+        
         else:
-            self.custom_tags.setChecked(False)
-            self.custom_tags.setEnabled(False)
-            self.postags_box.setEnabled(False)
+            if story_elements is not None:
+                self.Error.clear()
+                self.story_elements = util.convert_orangetable_to_dataframe(story_elements)
+                self.actiontagger = ActionTagger(self.story_elements['lang'].tolist()[0])
+                self.start(
+                    self.run, 
+                    self.story_elements
+                )
+                self.postags_box.setEnabled(True)
+            else:
+                self.custom_tags.setChecked(False)
+                self.custom_tags.setEnabled(False)
+                self.postags_box.setEnabled(False)
 
         self.setup_controls()
         self.doc_list.model().set_filter_string(self.regexp_filter)

--- a/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
@@ -328,13 +328,11 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
         actor_action_table_selected = Output("Action table: selected", Table)
         actor_action_table_full = Output("Action table: all", Table)
 
-
     class Error(OWWidget.Error):
         wrong_input_for_stories = error_handling.wrong_input_for_stories
         wrong_input_for_elements = error_handling.wrong_input_for_elements
         residual_error = error_handling.residual_error
         
-
     settingsHandler = DomainContextHandler()
     settings_version = 2
     search_features: List[Variable] = ContextSetting([])
@@ -501,10 +499,13 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
         """Stories expects a Corpus. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs.         
         """
-        if not isinstance(stories, Corpus):
-            self.Error.wrong_input_for_stories()
+        if stories is not None:
+            if not isinstance(stories, Corpus):
+                self.Error.wrong_input_for_stories()
+            else:
+                self.stories = stories
+                self.Error.clear()
         else:
-            self.stories = stories
             self.Error.clear()
 
         if self.story_elements is not None:
@@ -523,11 +524,11 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
     def set_story_elements(self, story_elements=None):
         """Story elements expects a table. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs."""
-        if isinstance(story_elements, Corpus): 
-            self.Error.wrong_input_for_elements()
-        
-        else:
-            if story_elements is not None:
+
+        if story_elements is not None:
+            if isinstance(story_elements, Corpus): 
+                self.Error.wrong_input_for_elements()
+            else:
                 self.Error.clear()
                 self.story_elements = util.convert_orangetable_to_dataframe(story_elements)
                 self.actiontagger = ActionTagger(self.story_elements['lang'].tolist()[0])
@@ -535,11 +536,12 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
                     self.run, 
                     self.story_elements
                 )
-                self.postags_box.setEnabled(True)
-            else:
-                self.custom_tags.setChecked(False)
-                self.custom_tags.setEnabled(False)
-                self.postags_box.setEnabled(False)
+                self.postags_box.setEnabled(True)     
+        else:
+            self.custom_tags.setChecked(False)
+            self.custom_tags.setEnabled(False)
+            self.postags_box.setEnabled(False)
+            self.Error.clear()
 
         self.setup_controls()
         self.doc_list.model().set_filter_string(self.regexp_filter)

--- a/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
@@ -588,13 +588,10 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
 
         if self.story_elements is not None:
             self.Error.clear()
-            try:
-                self.start(
-                    self.run, 
-                    self.story_elements
-                )
-            except Exception as e:
-                self.Error.residual_error()
+            self.start(
+                self.run, 
+                self.story_elements
+            )
 
         self.setup_controls()
         self.doc_list.model().set_filter_string(self.regexp_filter)
@@ -611,16 +608,13 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
         else:
             if story_elements is not None:
                 self.Error.clear()
-                try:
-                    self.story_elements = util.convert_orangetable_to_dataframe(story_elements)
-                    self.actortagger = ActorTagger(self.story_elements['lang'].tolist()[0])
-                    self.start(
-                        self.run, 
-                        self.story_elements
-                    )
-                    self.postags_box.setEnabled(True)
-                except Exception as e:
-                    self.Error.residual_error()
+                self.story_elements = util.convert_orangetable_to_dataframe(story_elements)
+                self.actortagger = ActorTagger(self.story_elements['lang'].tolist()[0])
+                self.start(
+                    self.run, 
+                    self.story_elements
+                )
+                self.postags_box.setEnabled(True)
             else:
                 self.nc.setChecked(False)
                 self.sc.setChecked(False)

--- a/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
@@ -46,6 +46,7 @@ from orangecontrib.text.corpus import Corpus
 from storynavigation.modules.actoranalysis import ActorTagger
 import storynavigation.modules.constants as constants
 import storynavigation.modules.util as util
+import storynavigation.modules.error_handling as error_handling
 
 HTML = """
 <!doctype html>
@@ -330,25 +331,10 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
         customfreq_table = Output("Custom tag stats: all", Table)
 
     class Error(OWWidget.Error):
-        msg_wrong_input_for_stories = (
-            "Wrong input to `Stories`. "
-            "The input to `Story elements` needs to be a `Table`. \n"
-            "The input to `Stories` needs to be a `Corpus`." 
-        )
-        wrong_input_for_stories = Msg(msg_wrong_input_for_stories)
-
-        msg_wrong_input_for_elements = (
-            "Wrong input to `Story elements`. "
-            "The input to `Story elements` needs to be a `Table`. \n"
-            "The input to `Stories` needs to be a `Corpus`."
-        ) 
-        wrong_input_for_elements = Msg(msg_wrong_input_for_elements)
-
-        msg_residual_error = (
-            "Could not process data. Check the inputs to the widget."
-        )
-        residual_error = Msg(msg_residual_error)
-
+        wrong_input_for_stories = error_handling.wrong_input_for_stories
+        wrong_input_for_elements = error_handling.wrong_input_for_elements
+        residual_error = error_handling.residual_error
+        
 
     settingsHandler = DomainContextHandler()
     settings_version = 2

--- a/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
@@ -566,10 +566,13 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
         """Stories expects a Corpus. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs.         
         """
-        if not isinstance(stories, Corpus):
-            self.Error.wrong_input_for_stories()
+        if (stories is not None):
+            if not isinstance(stories, Corpus):
+                self.Error.wrong_input_for_stories()
+            else:
+                self.stories = stories
+                self.Error.clear()
         else:
-            self.stories = stories
             self.Error.clear()
 
         if self.story_elements is not None:
@@ -588,11 +591,11 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
     def set_story_elements(self, story_elements=None):
         """Story elements expects a table. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs."""
-        if isinstance(story_elements, Corpus): 
-            self.Error.wrong_input_for_elements()
 
-        else:
-            if story_elements is not None:
+        if story_elements is not None:
+            if isinstance(story_elements, Corpus): 
+                self.Error.wrong_input_for_elements()
+            else:
                 self.Error.clear()
                 self.story_elements = util.convert_orangetable_to_dataframe(story_elements)
                 self.actortagger = ActorTagger(self.story_elements['lang'].tolist()[0])
@@ -601,17 +604,17 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
                     self.story_elements
                 )
                 self.postags_box.setEnabled(True)
-            else:
-                self.nc.setChecked(False)
-                self.sc.setChecked(False)
-                self.allc.setChecked(False)
-                self.custom_tags.setChecked(False)
-
-                self.custom_tags.setEnabled(False)
-                self.postags_box.setEnabled(False)
-                self.main_agents_box.setEnabled(False)
-                self.metric_name_combo.setEnabled(False)
-
+        else:
+            self.nc.setChecked(False)
+            self.sc.setChecked(False)
+            self.allc.setChecked(False)
+            self.custom_tags.setChecked(False)
+            self.custom_tags.setEnabled(False)
+            self.postags_box.setEnabled(False)
+            self.main_agents_box.setEnabled(False)
+            self.metric_name_combo.setEnabled(False)
+            self.Error.clear()
+                
         self.setup_controls()
         self.doc_list.model().set_filter_string(self.regexp_filter)
         self.list_docs()

--- a/orangecontrib/storynavigation/widgets/OWSNTagger.py
+++ b/orangecontrib/storynavigation/widgets/OWSNTagger.py
@@ -103,19 +103,18 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
     def set_stories(self, stories=None):
         idx = 0
         self.stories = []
-        for document in stories:
-            text = ''
-            for field in stories.domain.metas:
-                text_field_name = str(field)
-                if text_field_name.lower() in ['text', 'content']:
-                    text = str(stories[idx, text_field_name])
+        if stories is not None:
+            for document in stories:
+                text = ''
+                for field in stories.domain.metas:
+                    text_field_name = str(field)
+                    if text_field_name.lower() in ['text', 'content']:
+                        text = str(stories[idx, text_field_name])
 
-            if len(text) > 0:
-                self.stories.append((text, idx))
-            else:
-                print(idx)
+                if len(text) > 0:
+                    self.stories.append((text, idx))
 
-            idx += 1
+                idx += 1
 
     @Inputs.custom_tag_dict
     def set_custom_tags(self, custom_tag_dict=None):


### PR DESCRIPTION
##### Issue
Workaround to fix #42 

##### Description of changes
- Added an `Error` property to the actor analysis widget 
- raises error when wrong input type for `stories`. The error only goes away when the right input for `Stories` is provided.

##### Questions 
- should we also check input types for `story_elements`? What is the exact control flow then, with the `if story_elements is not None`
- should we also do the same for the action analysis widget?


##### Includes
- [X] Code changes

