### PR TITLE
Solving issue44 and issue37

### DIFF
--- a/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
@@ -499,6 +499,7 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
         """Stories expects a Corpus. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs.         
         """
+        self.valid_stories = []
         if stories is not None:
             if not isinstance(stories, Corpus):
                 self.Error.wrong_input_for_stories()
@@ -525,6 +526,8 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
         """Story elements expects a table. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs."""
 
+        self.valid_stories = []
+        
         if story_elements is not None:
             if isinstance(story_elements, Corpus): 
                 self.Error.wrong_input_for_elements()

--- a/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActorAnalysis.py
@@ -568,6 +568,7 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
         """Stories expects a Corpus. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs.         
         """
+        self.valid_stories = []
         if (stories is not None):
             if not isinstance(stories, Corpus):
                 self.Error.wrong_input_for_stories()
@@ -594,6 +595,8 @@ class OWSNActorAnalysis(OWWidget, ConcurrentWidgetMixin):
         """Story elements expects a table. Because Corpus is a subclass of Table, Orange type checking 
         misses wrongly connected inputs."""
 
+        self.valid_stories = []
+        
         if story_elements is not None:
             if isinstance(story_elements, Corpus): 
                 self.Error.wrong_input_for_elements()


### PR DESCRIPTION
##### Issues

#44 #37 
<!-- Solving issue44 and issue37. -->

##### Description of changes
At the parts where data is read into the actors and actions widget (@Inputs.story_elements and @Inputs.stories), the self.valid_stories is initialized to null. This avoids that former stories that were already loaded are appended to the list of new loaded stories. 

##### Includes
- [X] Code changes

