### PR TITLE
Solved issue 40

### DIFF
--- a/orangecontrib/storynavigation/widgets/OWSNTagger.py
+++ b/orangecontrib/storynavigation/widgets/OWSNTagger.py
@@ -89,8 +89,6 @@ class OWSNTagger(OWWidget, ConcurrentWidgetMixin):
             self,
             label="Extract story elements!",
             callback=self.__generate_dataset_level_data,
-            width=165,
-            height=45,
             toggleButton=False,
             sizePolicy=QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed),
             styleSheet="""


### PR DESCRIPTION
##### Issue

#40 

<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
<!-- Or a short description, if the issue does not exist. -->

##### Description of changes

The size of the button was too small to show the button label on Ubuntu Linux. The button width and height definitions were removed. The assigned default sizes proved to be accurate.

##### Includes
- [X] Code changes
