### PR TITLE
solves #issue82 by fixing the comparison between a Series and a list

### DIFF
--- a/orangecontrib/storynavigation/modules/actionanalysis.py
+++ b/orangecontrib/storynavigation/modules/actionanalysis.py
@@ -222,7 +222,8 @@ class ActionTagger:
             current_frame.rename(columns={cust_tag_col: 'category'}, inplace=True)
             combined_df = pd.concat([combined_df, current_frame], axis=0)
 
-        combined_df = combined_df[combined_df['category'] not in ['?', 'nan']]
+        #combined_df = combined_df[combined_df['category'] not in ['?', 'nan']]
+        combined_df = combined_df[~combined_df['category'].isin(['?', 'nan'])]
         return combined_df.reset_index(drop=True)
     
     def calculate_customfreq_table(self, df, selected_stories=None):

--- a/orangecontrib/storynavigation/modules/actoranalysis.py
+++ b/orangecontrib/storynavigation/modules/actoranalysis.py
@@ -47,7 +47,9 @@ class ActorTagger:
             current_frame.rename(columns={cust_tag_col: 'category'}, inplace=True)
             combined_df = pd.concat([combined_df, current_frame], axis=0)
         
-        combined_df = combined_df[combined_df['category'] not in ['?', 'nan']]
+        #combined_df = combined_df[combined_df['category'] not in ['?', 'nan']]
+        combined_df = combined_df[~combined_df['category'].isin(['?', 'nan'])]
+
         return combined_df.reset_index(drop=True)
 
     def __filter_rows(self, story_elements_df, pos_tags):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Resolves #2, Closes #4 etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #issue82. 

A previous bugfix around >>combined_df = combined_df[combined_df['category'] not in ['?', 'nan']] << was wrong in the sense that it was trying to check if the entire combined_df['category'] Series is "not in" the list ['?', 'nan']. This boils down to a comparison between a Series and a list, which led to a ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().

##### Description of changes
To properly filter the DataFrame by checking if each element in the category column is not in the list ['?', 'nan'], now the .isin() method is used in combination with the negation operator '~'

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
