### PR TITLE
os.linesep changed to \n

### DIFF
--- a/orangecontrib/storynavigation/modules/actionanalysis.py
+++ b/orangecontrib/storynavigation/modules/actionanalysis.py
@@ -383,8 +383,8 @@ class ActionTagger:
             lang (string): the ISO code for the language of the input stories (e.g. 'nl' or 'en'). Currently only 'nl' and 'en' are supported
         """
         if lang == constants.NL:
-            self.stopwords = constants.NL_STOPWORDS_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.stopwords = constants.NL_STOPWORDS_FILE.read_text(encoding="utf-8").split("\n")
         else:
-            self.stopwords = constants.EN_STOPWORDS_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.stopwords = constants.EN_STOPWORDS_FILE.read_text(encoding="utf-8").split("\n")
 
         self.stopwords = [item for item in self.stopwords if len(item) > 0]

--- a/orangecontrib/storynavigation/modules/actoranalysis.py
+++ b/orangecontrib/storynavigation/modules/actoranalysis.py
@@ -368,8 +368,8 @@ class ActorTagger:
             lang (string): the ISO code for the language of the input stories (e.g. 'nl' or 'en'). Currently only 'nl' and 'en' are supported
         """
         if lang == constants.NL:
-            self.stopwords = constants.NL_STOPWORDS_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.stopwords = constants.NL_STOPWORDS_FILE.read_text(encoding="utf-8").split("\n")
         else:
-            self.stopwords = constants.EN_STOPWORDS_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.stopwords = constants.EN_STOPWORDS_FILE.read_text(encoding="utf-8").split("\n")
 
         self.stopwords = [item for item in self.stopwords if len(item) > 0]

--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -496,19 +496,19 @@ class Tagger:
             lang (string): the ISO code for the language of the input stories (e.g. 'nl' or 'en'). Currently only 'nl' and 'en' are supported
         """
         if lang == constants.NL:
-            self.stopwords = constants.NL_STOPWORDS_FILE.read_text(encoding="utf-8").split(os.linesep)
-            self.pronouns = constants.NL_PRONOUNS_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.stopwords = constants.NL_STOPWORDS_FILE.read_text(encoding="utf-8").split("\n")
+            self.pronouns = constants.NL_PRONOUNS_FILE.read_text(encoding="utf-8").split("\n")
             self.model = constants.NL_SPACY_MODEL
-            self.past_tense_verbs = constants.NL_PAST_TENSE_FILE.read_text(encoding="utf-8").split(os.linesep)
-            self.present_tense_verbs = constants.NL_PRESENT_TENSE_FILE.read_text(encoding="utf-8").split(os.linesep)
-            self.false_positive_verbs = constants.NL_FALSE_POSITIVE_VERB_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.past_tense_verbs = constants.NL_PAST_TENSE_FILE.read_text(encoding="utf-8").split("\n")
+            self.present_tense_verbs = constants.NL_PRESENT_TENSE_FILE.read_text(encoding="utf-8").split("\n")
+            self.false_positive_verbs = constants.NL_FALSE_POSITIVE_VERB_FILE.read_text(encoding="utf-8").split("\n")
         else:
-            self.stopwords = constants.EN_STOPWORDS_FILE.read_text(encoding="utf-8").split(os.linesep)
-            self.pronouns = constants.EN_PRONOUNS_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.stopwords = constants.EN_STOPWORDS_FILE.read_text(encoding="utf-8").split("\n")
+            self.pronouns = constants.EN_PRONOUNS_FILE.read_text(encoding="utf-8").split("\n")
             self.model = constants.EN_SPACY_MODEL
-            self.past_tense_verbs = constants.EN_PAST_TENSE_FILE.read_text(encoding="utf-8").split(os.linesep)
-            self.present_tense_verbs = constants.EN_PRESENT_TENSE_FILE.read_text(encoding="utf-8").split(os.linesep)
-            self.false_positive_verbs = constants.EN_FALSE_POSITIVE_VERB_FILE.read_text(encoding="utf-8").split(os.linesep)
+            self.past_tense_verbs = constants.EN_PAST_TENSE_FILE.read_text(encoding="utf-8").split("\n")
+            self.present_tense_verbs = constants.EN_PRESENT_TENSE_FILE.read_text(encoding="utf-8").split("\n")
+            self.false_positive_verbs = constants.EN_FALSE_POSITIVE_VERB_FILE.read_text(encoding="utf-8").split("\n")
 
         self.stopwords = [item for item in self.stopwords if len(item) > 0]
         self.pronouns = [item for item in self.pronouns if len(item) > 0]


### PR DESCRIPTION
### Issue

#97 

### Description of changes

The Windows bug was reproduced on Linux. It seems the Storynavigator method for reading resource local files (pathlib.PosixPath / read_text) by default replaces all "\r\n" sequences by "\n". The bug is expected to be fixed by having changed all variables os.linesep with "\n" in the files actionanalysis.py actoranalysis.py and tagging.py 


### Includes

- [X] Code changes
- [ ] Tests
- [ ] Documentation
