### PR TITLE
Added auxilary verbs to be highlighted as well when stopwords are not…

### DIFF
--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -211,7 +211,7 @@ class Tagger:
         return row
     
     def __process_english_potential_action(self, tag):
-        if (tag[-1].pos_ ["VERB","AUX"]):
+        if (tag[-1].pos_ in ["VERB","AUX"]):
             # VB  --  verb, base form
             # VBD  --  verb, past tense
             # VBG  --  verb, gerund or present participle

--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -211,7 +211,7 @@ class Tagger:
         return row
     
     def __process_english_potential_action(self, tag):
-        if (tag[-1].pos_ == "VERB"):
+        if (tag[-1].pos_ ["VERB","AUX"]):
             # VB  --  verb, base form
             # VBD  --  verb, past tense
             # VBG  --  verb, gerund or present participle
@@ -231,7 +231,7 @@ class Tagger:
 
     def __process_dutch_potential_action(self, tag):
         # First check Spacy's dependency parser to classify as Verb and if so, past or present tense Verb?
-        if (tag[-1].pos_ == "VERB" and tag[-1].tag_.split('|')[0] == "WW"):                                                                               # Spacy recognizes word as a Verb
+        if (tag[-1].pos_ in ["VERB","AUX"] and tag[-1].tag_.split('|')[0] == "WW"):                                                                               # Spacy recognizes word as a Verb
             # Present tense == WW|pv|tgw or WW|pv|conj
             #   * Potentially include WW|inf category (see below)
             # Past tense == WW|pv|verl

--- a/orangecontrib/storynavigation/modules/util.py
+++ b/orangecontrib/storynavigation/modules/util.py
@@ -292,7 +292,7 @@ def find_verb_ancestor(token):
     """
     if isinstance(token, spacy.tokens.token.Token):
         # Check if the token is a verb
-        if token.pos_ == "VERB":
+        if token.pos_ in ["VERB","AUX"]:
             return token
 
         # Traverse the token's ancestors recursively


### PR DESCRIPTION
This PR solves issue #84, so that now the auxiliary verbs are also highlighted (both past and present) in the actions widget. This happens only when in the elements widget the option is selected to not remove the stopwords, otherwise these auxilary verbs will not be highlighted   