### PR TITLE
tag future tense verbs

### DIFF
--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -288,19 +288,27 @@ class Tagger:
                 
                                
              # Convert the collected rows into a DataFrame
-        return pd.DataFrame(rows)    
+        return pd.DataFrame(rows)
         
         
      
     def __process_potential_action(self, tag):
         if self.lang == constants.NL:
-            return self.__process_dutch_potential_action(tag)
-            return self.__process_dutch_future_verbs(tag)
+            return self.__process_dutch_potential_action(tag)            
         elif self.lang == constants.EN:
             return self.__process_english_potential_action(tag)
         else: 
             return "-"
+    
+    def __process_future_verb(self, sentence):
+        if self.lang == constants.NL:            
+            return self.__process_dutch_future_verbs(sentence)
+        # elif self.lang == constants.EN:
+        #     return self.__process_english_future_verbs(sentence)
+        else: 
+            return "-"
         
+    
     def __process_non_noun_tag(self, storyid, sentence, tag):
         """Given a tagged token in a sentence within a specific story known to not be a noun (potentially a verb), this function processes and appends data about this action to the master output dataframe
 

--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -12,7 +12,6 @@ from nltk.tokenize import RegexpTokenizer
 from Orange.data.pandas_compat import table_to_frames
 import spacy
 
-#nlp = spacy.load("nl_core_news_sm") 
 
 class Tagger:
     """Class to perform NLP tagging of relevant actors and actions in textual stories
@@ -282,7 +281,7 @@ class Tagger:
         # Loop through each token in the sentence
         for tok in tags:
             lemma_value = tok[10]
-            text_value = tok[5]
+            text_value = tok[2]
             pos_value = tok[6]
             tag_value = tok[7]
             dep_value = tok[8]

--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -174,6 +174,7 @@ class Tagger:
             future_verb = self.__process_dutch_future_verbs(story_df_rows, row)
             row.append(future_verb)           
             
+            # overwrite the verb value if it's a future verb
             if future_verb == "FUTURE_VB":
                 row[5] = "FUTURE_VB"
                             
@@ -289,14 +290,14 @@ class Tagger:
             # Check if the token is an auxiliary 'zullen' or 'gaan' or a conjugation of it
             if lemma_value in ["zullen", "gaan"] and pos_value == "AUX":
                 future_verb_triggered = True
-                continue  # Move to the next token to check for infinitives
+                continue
 
             # Check if the specific token is an infinitive verb that follows 'zullen' or 'gaan'
             if future_verb_triggered and tag_value.startswith("WW|inf|"):
             # Classify the infinitive as FUTURE_VB if it's the target token
                 if tok == tag:
                     return "FUTURE_VB"
-                continue  # Keep marking subsequent infinitives as FUTURE_VB            
+                continue  # Keep marking subsequent infinitives as FUTURE_VB
                                  
             # reset the future_verb_triggered flag whenever a clause boundary is detected
             if dep_value == "punct" and text_value in [";", ",", ".", ":", "?", "!"]:

--- a/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
+++ b/orangecontrib/storynavigation/widgets/OWSNActionAnalysis.py
@@ -126,6 +126,9 @@ img {{
 <mark class="entity" style="background: #DB7093; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;">
     Action | present tense
 </mark>
+<mark class="entity" style="background: #C7BFC2; padding: 0.45em 0.6em; margin: 0 0.25em; line-height: 1; border-radius: 0.35em;">
+    Action | future tense
+</mark>
 {}
 </div>
 <br/>
@@ -348,6 +351,7 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
     # Parts of speech (POS) checkbox selected initialization
     past_vbz = Setting(True)
     present_vbz = Setting(True)
+    future_vbz = Setting(True)
     all_pos = Setting(True)
     zero_pos = Setting(False)
     custom = Setting(True)
@@ -420,6 +424,13 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
             "Actions - present tense",
             callback=self.pos_selection_changed,
         )
+        self.futurevc = gui.checkBox(
+            self.postags_box,
+            self,
+            "future_vbz",
+            "Actions - future tense",
+            callback=self.pos_selection_changed,
+        )
 
         self.custom_tags = gui.checkBox(
             self.postags_box,
@@ -435,7 +446,7 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
         self.allc = gui.checkBox(self.postags_box, self, "all_pos", "All")
         self.allc.setChecked(False)
         self.allc.stateChanged.connect(self.on_state_changed_pos)
-        self.pos_checkboxes = [self.pastvc, self.presentvc, self.custom_tags]
+        self.pos_checkboxes = [self.pastvc, self.presentvc, self.futurevc, self.custom_tags]
 
         self.controlArea.layout().addWidget(self.postags_box)
         # Auto-commit box
@@ -806,6 +817,7 @@ class OWSNActionAnalysis(OWWidget, ConcurrentWidgetMixin):
                             value,
                             self.past_vbz,
                             self.present_vbz,
+                            self.future_vbz,
                             self.custom,
                             self.story_elements_dict[str(c_index)]
                         )


### PR DESCRIPTION
This pull request introduces the ability to tag future tense verbs in the action analysis module. It includes updates to both the backend logic for tagging verbs and the user interface to support this new feature. This solves issue #93 

### Backend changes:
* Added support for tagging future tense verbs in the `__postag_sents` and `postag_text` methods by introducing a new `future_vbz` parameter. 
* Added the `future_verb` column to the `complete_data_columns` list in the `Tagger` class.
* Implemented the `__process_dutch_future_verbs` method to identify future tense verbs in Dutch.
* Updated the `__parse_tagged_story` method to include future tense verbs in the story dataframe.

### UI changes:
* Added a checkbox for "Actions - future tense" in the `OWSNActionAnalysis` widget.
* Updated the `show_docs` method to pass the `future_vbz` parameter.
* Added a new HTML mark style for future tense actions.