### PR TITLE
Voice determination (active or passive) functionality for Dutch sentences

### DIFF
--- a/orangecontrib/storynavigation/modules/tagging.py
+++ b/orangecontrib/storynavigation/modules/tagging.py
@@ -358,7 +358,7 @@ class Tagger:
             pos_value = tok[1]  
             tag_value = tok[2]  
             dep_value = tok[3]  # Dependency relation
-            head_value = tok[5].head.text  # Syntactic head (index of the parent token)
+            head_value = tok[5].head.lemma_  # Syntactic head (index of the parent token)
 
             # Check for auxiliary verbs (e.g., "moeten", "kunnen") that might chain with "worden" or "zijn"
             if pos_value == auxiliary_pos_tag and lemma_value not in passive_auxiliaries:


### PR DESCRIPTION
This pull request includes several changes to the `orangecontrib/storynavigation/modules/tagging.py` file, focusing on adding voice determination functionality for Dutch sentences and improving code readability. The most important changes include updating the data columns, adding a new method to process Dutch voice, and appending the voice information to the data rows. 

Solves issue #126 

### Voice determination and data processing:

* Updated `self.complete_data_columns` to include the new 'voice' column.
* Added a new method `__process_dutch_voice` to determine if a Dutch sentence or clause is in the passive or active voice.
* Modified `__parse_tagged_story` to determine the voice for each sentence and append this information to the data rows. [[1]](diffhunk://#diff-fb61e723cc0c19cb0c99a7dd27f31e4435001acfdf025c2c3861018f7199f3c4R157-R184) [[2]](diffhunk://#diff-fb61e723cc0c19cb0c99a7dd27f31e4435001acfdf025c2c3861018f7199f3c4R194)

### Code readability improvements:

* Improved the docstring format for the `__parse_tagged_story` method for better readability.
* Added whitespace for better code organization and readability.