### PR TITLE
Added frequencies of future verbs in action stats

### DIFF
--- a/orangecontrib/storynavigation/modules/actionanalysis.py
+++ b/orangecontrib/storynavigation/modules/actionanalysis.py
@@ -373,7 +373,7 @@ class ActionTagger:
         if word_col is None:
             word_col = 'token_text_lowercase'
             
-        past_or_present_tense_verbs_df = story_elements_df[story_elements_df['story_navigator_tag'].isin(['PRES_VB', 'PAST_VB'])]
+        past_or_present_tense_verbs_df = story_elements_df[story_elements_df['story_navigator_tag'].isin(['PRES_VB', 'PAST_VB','FUTURE_VB'])]
         result_df = past_or_present_tense_verbs_df.groupby(['storyid', 'segment_id', 'story_navigator_tag'])[word_col].agg(word_col='nunique').reset_index().rename(columns={word_col: "tense_freq"})
 
         return result_df


### PR DESCRIPTION
This pull request includes a change to the `generate_action_analysis_results` method in the `orangecontrib/storynavigation/modules/actionanalysis.py` file. The change involves updating the filtering criteria for story elements to include future tense verbs, so that the frequencies of future verbs are also shown in the action stats table.

Solves issue #154

* Updated `generate_action_analysis_results` method to include 'FUTURE_VB' in the filtering criteria for `story_navigator_tag`.